### PR TITLE
[feat] useTimeSInce 훅 생성

### DIFF
--- a/dojang-crush/src/hooks/useTimeSince.js
+++ b/dojang-crush/src/hooks/useTimeSince.js
@@ -1,0 +1,35 @@
+import React, { useState, useEffect } from 'react';
+
+const useTimeSince = (createdDate) => {
+    const [timeSince, setTimeSince] = useState('');
+
+    useEffect(() => {
+        const calculateTimeSince = () => {
+            const now = new Date();
+            const created = new Date(createdDate);
+            const diffInMilliseconds = now - created;
+            const diffInMinutes = Math.floor(diffInMilliseconds / 60000);
+            const diffInHours = Math.floor(diffInMilliseconds / (60000 * 60));
+            const diffInDays = Math.floor(
+                diffInMilliseconds / (60000 * 60 * 24)
+            );
+
+            if (diffInMinutes < 60) {
+                setTimeSince(`${diffInMinutes}분 전`);
+            } else if (diffInHours < 24) {
+                setTimeSince(`${diffInHours}시간 전`);
+            } else {
+                setTimeSince(`${diffInDays}일 전`);
+            }
+        };
+
+        calculateTimeSince();
+        const intervalId = setInterval(calculateTimeSince, 60000); // 1분마다 업데이트
+
+        return () => clearInterval(intervalId);
+    }, [createdDate]);
+
+    return timeSince;
+};
+
+export default useTimeSince;


### PR DESCRIPTION
# 구현 기능

타임라인과 게시물 상세에서 사용하는 ["몇분 전", "몇시간 전", "몇일 전"] 훅을 만들었습니다.

사용법은 게시물 내용을 request 할 때 받아오는 createDate 값을 그대로 인자로 넣으면 됩니다.

아래 코드는 사용 예시입니다.

<img width="520" alt="image" src="https://github.com/user-attachments/assets/8662eab6-4d81-4551-934a-11037c1b8fed">

궁금한 점 있으면 댓글 남겨주세요!